### PR TITLE
Improve Plotly dependency error handling guidance

### DIFF
--- a/streamlit-gantt/app.py
+++ b/streamlit-gantt/app.py
@@ -34,7 +34,7 @@ st.set_page_config(page_title="工事受注案件ガントチャート", layout=
 
 if PLOTLY_IMPORT_ERROR:
     st.error(
-        "Plotly 関連のライブラリが見つかりません。"
+        "Plotly 関連のライブラリが見つかりません。\n"
         "アプリを利用するには `pip install -r requirements.txt` を実行して"
         "必要な依存関係をインストールしてください。\n\n"
         f"詳細: {PLOTLY_IMPORT_ERROR}"


### PR DESCRIPTION
## Summary
- adjust the missing Plotly dependency error message to clearly instruct users to install requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d889c5287c8323be189a75a57480d9