### PR TITLE
Handle optional Kaleido dependency for PNG export

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This repository contains a Streamlit application for visualising construction pr
    # Or, if you prefer working inside the app directory
    pip install -r streamlit-gantt/requirements.txt
    ```
+   If you need PNG export support, install [Kaleido](https://github.com/plotly/Kaleido) as an optional dependency:
+   ```bash
+   pip install kaleido
+   ```
 3. Launch the Streamlit app:
    ```bash
    streamlit run streamlit-gantt/app.py

--- a/streamlit-gantt/README.md
+++ b/streamlit-gantt/README.md
@@ -18,6 +18,9 @@ venv\\Scripts\\Activate.ps1
 # 依存関係のインストール
 pip install -r requirements.txt
 
+# PNG 出力が必要な場合は追加で Kaleido をインストール
+pip install kaleido
+
 # アプリの起動
 streamlit run app.py
 ```

--- a/streamlit-gantt/app.py
+++ b/streamlit-gantt/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 from datetime import datetime
 from pathlib import Path
 from typing import List
@@ -62,6 +63,12 @@ def _load_initial_projects() -> pd.DataFrame:
     if "color" not in df.columns:
         df["color"] = ""
     return df
+
+
+def _has_kaleido() -> bool:
+    """Return True when Kaleido is available for static image export."""
+
+    return importlib.util.find_spec("kaleido") is not None
 
 
 def _build_segments(projects: pd.DataFrame) -> pd.DataFrame:
@@ -197,11 +204,14 @@ with col_chart:
 with col_export:
     st.markdown("#### 出力")
     if st.button("PNG生成", use_container_width=True):
-        try:
-            png_bytes = pio.to_image(fig, format="png", engine="kaleido", width=1600, height=900, scale=2)
-            st.download_button("PNGダウンロード", png_bytes, file_name="gantt.png")
-        except Exception as exc:  # noqa: BLE001
-            st.error(f"PNG 出力に失敗しました: {exc}")
+        if not _has_kaleido():
+            st.info("PNG 出力には Kaleido が必要です。`pip install kaleido` を実行してください。")
+        else:
+            try:
+                png_bytes = pio.to_image(fig, format="png", engine="kaleido", width=1600, height=900, scale=2)
+                st.download_button("PNGダウンロード", png_bytes, file_name="gantt.png")
+            except Exception as exc:  # noqa: BLE001
+                st.error(f"PNG 出力に失敗しました: {exc}")
 
 if event:
     selected = event[0]

--- a/streamlit-gantt/requirements.txt
+++ b/streamlit-gantt/requirements.txt
@@ -1,6 +1,5 @@
 streamlit==1.35.0
 pandas==2.2.2
 plotly==5.22.0
-kaleido==0.2.1
 streamlit-plotly-events==0.0.6
 numpy==1.26.4


### PR DESCRIPTION
## Summary
- remove Kaleido from the default dependency set and document it as an optional install
- guard PNG export behind a Kaleido availability check with a helpful Streamlit message

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d88d9dccbc83238feeb064b4533f5b