### PR TITLE
Improve handling of missing Plotly dependencies

### DIFF
--- a/streamlit-gantt/app.py
+++ b/streamlit-gantt/app.py
@@ -13,13 +13,13 @@ import streamlit as st
 from components.editor import render_editor
 from components.filters import render_sidebar
 from utils import Segment
+from utils.dependencies import import_plotly_streamlit_runtime
 from utils.state import init_state, redo, undo
 
 PLOTLY_IMPORT_ERROR: str | None = None
 
 try:  # pragma: no cover - environment dependent import
-    import plotly.io as pio
-    from streamlit_plotly_events import plotly_events
+    pio, plotly_events = import_plotly_streamlit_runtime()
 except ModuleNotFoundError as exc:  # pragma: no cover - executed when optional deps missing
     pio = None  # type: ignore[assignment]
     plotly_events = None  # type: ignore[assignment]
@@ -44,14 +44,7 @@ DEFAULT_FILE = DATA_DIR / "sample_projects.csv"
 st.set_page_config(page_title="工事受注案件ガントチャート", layout="wide")
 
 if PLOTLY_IMPORT_ERROR:
-    st.error(
-        "Plotly 関連のライブラリが見つかりません。\n"
-        "アプリを利用するには以下のコマンドのいずれかを実行して"
-        "必要な依存関係をインストールしてください。\n"
-        "  - `pip install -r requirements.txt` (streamlit-gantt ディレクトリで実行)\n"
-        "  - `pip install -r streamlit-gantt/requirements.txt` (リポジトリルートで実行)\n\n"
-        f"詳細: {PLOTLY_IMPORT_ERROR}"
-    )
+    st.error(PLOTLY_IMPORT_ERROR)
     st.stop()
 
 

--- a/streamlit-gantt/components/gantt.py
+++ b/streamlit-gantt/components/gantt.py
@@ -8,17 +8,17 @@ from typing import Any, Iterable
 import numpy as np
 import pandas as pd
 
+from utils.dependencies import import_plotly_core
+from utils.dates import make_month_annotations, make_tickvals, make_week_lines
+
 PLOTLY_IMPORT_ERROR: str | None = None
 
 try:  # pragma: no cover - optional dependency import
-    import plotly.express as px
-    import plotly.graph_objects as go
+    go, px = import_plotly_core()
 except ModuleNotFoundError as exc:  # pragma: no cover - executed when Plotly is missing
-    px = None  # type: ignore[assignment]
     go = None  # type: ignore[assignment]
+    px = None  # type: ignore[assignment]
     PLOTLY_IMPORT_ERROR = str(exc)
-
-from utils.dates import make_month_annotations, make_tickvals, make_week_lines
 
 DEFAULT_COLOR = "#f97316"
 PROGRESS_COLORS = {
@@ -61,11 +61,16 @@ def build_gantt_dataframe(
 def _ensure_plotly_modules() -> tuple[Any, Any]:
     """Return Plotly modules or raise a helpful error when unavailable."""
 
+    global go, px, PLOTLY_IMPORT_ERROR
+
     if go is None or px is None:
-        raise ModuleNotFoundError(
-            "Plotly is required to render the gantt chart. "
-            "Install the optional dependencies with `pip install -r requirements.txt`."
-        )
+        try:
+            go, px = import_plotly_core()
+        except ModuleNotFoundError as exc:  # pragma: no cover - executed when Plotly is missing
+            PLOTLY_IMPORT_ERROR = str(exc)
+            raise
+        else:  # pragma: no cover - executed when imports succeed
+            PLOTLY_IMPORT_ERROR = None
     return go, px
 
 

--- a/streamlit-gantt/utils/dependencies.py
+++ b/streamlit-gantt/utils/dependencies.py
@@ -1,0 +1,61 @@
+"""Utility helpers for optional dependency imports."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any, Callable, Iterable
+
+PLOTLY_INSTALL_INSTRUCTIONS = (
+    "Plotly 関連のライブラリが見つかりません。\n"
+    "アプリを利用するには以下のコマンドのいずれかを実行して必要な依存関係をインストールしてください。\n"
+    "  - `pip install -r requirements.txt` (streamlit-gantt ディレクトリで実行)\n"
+    "  - `pip install -r streamlit-gantt/requirements.txt` (リポジトリルートで実行)"
+)
+
+
+def _load_modules(names: Iterable[str]) -> tuple[dict[str, ModuleType] | None, str | None]:
+    """Attempt to import modules, returning the first error message when missing."""
+
+    loaded: dict[str, ModuleType] = {}
+    for name in names:
+        try:
+            loaded[name] = import_module(name)
+        except ModuleNotFoundError as exc:  # pragma: no cover - depends on environment
+            return None, str(exc)
+    return loaded, None
+
+
+def format_plotly_error(details: str) -> str:
+    """Return a user-friendly error message for missing Plotly dependencies."""
+
+    return f"{PLOTLY_INSTALL_INSTRUCTIONS}\n\n詳細: {details}"
+
+
+def import_plotly_core() -> tuple[Any, Any]:
+    """Import the core Plotly modules required for chart rendering."""
+
+    modules, error = _load_modules(["plotly.graph_objects", "plotly.express"])
+    if error is not None:  # pragma: no cover - depends on environment
+        raise ModuleNotFoundError(format_plotly_error(error)) from None
+    return modules["plotly.graph_objects"], modules["plotly.express"]
+
+
+def import_plotly_streamlit_runtime() -> tuple[Any, Callable[..., Any]]:
+    """Import Plotly helpers used by the Streamlit front-end."""
+
+    modules, error = _load_modules(["plotly.io", "streamlit_plotly_events"])
+    if error is not None:  # pragma: no cover - depends on environment
+        raise ModuleNotFoundError(format_plotly_error(error)) from None
+
+    pio = modules["plotly.io"]
+    events_module = modules["streamlit_plotly_events"]
+    return pio, events_module.plotly_events
+
+
+__all__ = [
+    "PLOTLY_INSTALL_INSTRUCTIONS",
+    "format_plotly_error",
+    "import_plotly_core",
+    "import_plotly_streamlit_runtime",
+]


### PR DESCRIPTION
## Summary
- centralize Plotly dependency checks and install guidance in a new utility helper
- update the Gantt component and Streamlit app to use the helper so missing modules surface a consistent, user-friendly error message

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d88f9f31d08323ae4abf972a502b32